### PR TITLE
change some unique_ptr to shared_ptr

### DIFF
--- a/C--/BadExpression.cpp
+++ b/C--/BadExpression.cpp
@@ -8,6 +8,6 @@
 #include "Token.h"
 
 
-BadExpression::BadExpression(std::unique_ptr<Token> token) : Expression(BadExpressionType) {
-	this->token = std::move(token);
+BadExpression::BadExpression(std::shared_ptr<Token> token) : Expression(BadExpressionType) {
+	this->token = token;
 }

--- a/C--/BadExpression.h
+++ b/C--/BadExpression.h
@@ -8,7 +8,7 @@
 #include "Token.h"
 
 class BadExpression : public Expression {
-	std::unique_ptr<Token> token;
+	std::shared_ptr<Token> token;
 public:
-	BadExpression(std::unique_ptr<Token>);
+	BadExpression(std::shared_ptr<Token>);
 };

--- a/C--/BinaryExpression.cpp
+++ b/C--/BinaryExpression.cpp
@@ -5,9 +5,9 @@
 
 #include "Token.h"
 
-BinaryExpression::BinaryExpression(std::unique_ptr<Expression> left, std::unique_ptr<Token> operator_token, std::unique_ptr<Expression> right) : 
+BinaryExpression::BinaryExpression(std::shared_ptr<Expression> left, std::shared_ptr<Token> operator_token, std::shared_ptr<Expression> right) :
 	Expression(BinaryExpressionType) {
-	this->left = std::move(left);
-	this->operator_token = std::move(operator_token);
-	this->right = std::move(right);
+	this->left = left;
+	this->operator_token = operator_token;
+	this->right = right;
 }

--- a/C--/BinaryExpression.h
+++ b/C--/BinaryExpression.h
@@ -9,9 +9,9 @@
 
 class BinaryExpression : public Expression {
 public:
-	std::unique_ptr<Expression> left;
-	std::unique_ptr<Expression> right;
-	std::unique_ptr<Token> operator_token;
+	std::shared_ptr<Expression> left;
+	std::shared_ptr<Expression> right;
+	std::shared_ptr<Token> operator_token;
 
-	BinaryExpression(std::unique_ptr<Expression>, std::unique_ptr<Token>, std::unique_ptr<Expression>);
+	BinaryExpression(std::shared_ptr<Expression>, std::shared_ptr<Token>, std::shared_ptr<Expression>);
 };

--- a/C--/Evaluator.cpp
+++ b/C--/Evaluator.cpp
@@ -16,9 +16,9 @@
 Evaluator::Evaluator() {}
 
 
-int Evaluator::evaluate_expression(Expression* expression) {
+int Evaluator::evaluate_expression(std::shared_ptr<Expression> expression) {
 	if (expression->type == LiteralExpressionType) {
-		LiteralExpression* number_expression = dynamic_cast<LiteralExpression*>(expression);
+		std::shared_ptr<LiteralExpression> number_expression = std::dynamic_pointer_cast<LiteralExpression>(expression);
 
 		// Only if number expression is not nullptr (Dynamic cast was successfull)
 		if (number_expression) {
@@ -27,12 +27,12 @@ int Evaluator::evaluate_expression(Expression* expression) {
 	}
 
 	if (expression->type == BinaryExpressionType) {
-		BinaryExpression* binary_expression = dynamic_cast<BinaryExpression*>(expression);
+		std::shared_ptr<BinaryExpression> binary_expression = std::dynamic_pointer_cast<BinaryExpression>(expression);
 
 		// Only if binary expression is not nullptr (Dynamic cast was successfull)
 		if (binary_expression) {
-			int left = this->evaluate_expression(binary_expression->left.get());
-			int right = this->evaluate_expression(binary_expression->right.get());
+			int left = this->evaluate_expression(binary_expression->left);
+			int right = this->evaluate_expression(binary_expression->right);
 
 			switch (binary_expression->operator_token->type)
 			{
@@ -47,11 +47,11 @@ int Evaluator::evaluate_expression(Expression* expression) {
 	}
 
 	if (expression->type == ParenthesizedExpressionType) {
-		ParenthesizedExpression* parenthesized_expression = dynamic_cast<ParenthesizedExpression*>(expression);
+		std::shared_ptr<ParenthesizedExpression> parenthesized_expression = std::dynamic_pointer_cast<ParenthesizedExpression>(expression);
 
 		// Only if parenthesized expression is not nullptr (Dynamic cast was successfull)
 		if (parenthesized_expression) {
-			return this->evaluate_expression(parenthesized_expression->expression.get());
+			return this->evaluate_expression(parenthesized_expression->expression);
 		}
 	}
 

--- a/C--/Evaluator.cpp
+++ b/C--/Evaluator.cpp
@@ -16,32 +16,23 @@
 Evaluator::Evaluator() {}
 
 
-int Evaluator::evaluate_expression(std::unique_ptr<Expression> expression) {
+int Evaluator::evaluate_expression(Expression* expression) {
 	if (expression->type == LiteralExpressionType) {
-		LiteralExpression* number_expression_raw_ptr = dynamic_cast<LiteralExpression*>(expression.get());
+		LiteralExpression* number_expression = dynamic_cast<LiteralExpression*>(expression);
 
 		// Only if number expression is not nullptr (Dynamic cast was successfull)
-		if (number_expression_raw_ptr) {
-			// Remove pointer to the object to create new unique_ptr
-			expression.release();
-
-			std::unique_ptr<LiteralExpression> number_expression(number_expression_raw_ptr);
+		if (number_expression) {
 			return std::any_cast<int>(number_expression->value);
 		}
 	}
 
 	if (expression->type == BinaryExpressionType) {
-		BinaryExpression* binary_expression_raw_ptr = dynamic_cast<BinaryExpression*>(expression.get());
+		BinaryExpression* binary_expression = dynamic_cast<BinaryExpression*>(expression);
 
 		// Only if binary expression is not nullptr (Dynamic cast was successfull)
-		if (binary_expression_raw_ptr) {
-			// Remove pointer to the object to create new unique_ptr
-			expression.release();
-
-			std::unique_ptr<BinaryExpression> binary_expression(binary_expression_raw_ptr);
-
-			int left = this->evaluate_expression(std::move(binary_expression->left));
-			int right = this->evaluate_expression(std::move(binary_expression->right));
+		if (binary_expression) {
+			int left = this->evaluate_expression(binary_expression->left.get());
+			int right = this->evaluate_expression(binary_expression->right.get());
 
 			switch (binary_expression->operator_token->type)
 			{
@@ -56,15 +47,11 @@ int Evaluator::evaluate_expression(std::unique_ptr<Expression> expression) {
 	}
 
 	if (expression->type == ParenthesizedExpressionType) {
-		ParenthesizedExpression* parenthesized_expression_raw_ptr = dynamic_cast<ParenthesizedExpression*>(expression.get());
+		ParenthesizedExpression* parenthesized_expression = dynamic_cast<ParenthesizedExpression*>(expression);
 
 		// Only if parenthesized expression is not nullptr (Dynamic cast was successfull)
-		if (parenthesized_expression_raw_ptr) {
-			// Remove pointer to the object to create new unique_ptr
-			expression.release();
-
-			std::unique_ptr<ParenthesizedExpression> parenthesized_expression(parenthesized_expression_raw_ptr);
-			return this->evaluate_expression(std::move(parenthesized_expression->expression));
+		if (parenthesized_expression) {
+			return this->evaluate_expression(parenthesized_expression->expression.get());
 		}
 	}
 

--- a/C--/Evaluator.h
+++ b/C--/Evaluator.h
@@ -8,5 +8,5 @@ private:
 	std::unique_ptr<Expression> root;
 public:
 	Evaluator();
-	int evaluate_expression(std::unique_ptr<Expression>);
+	int evaluate_expression(Expression*);
 };

--- a/C--/Evaluator.h
+++ b/C--/Evaluator.h
@@ -5,8 +5,8 @@
 
 class Evaluator {
 private:
-	std::unique_ptr<Expression> root;
+	std::shared_ptr<Expression> root;
 public:
 	Evaluator();
-	int evaluate_expression(Expression*);
+	int evaluate_expression(std::shared_ptr<Expression>);
 };

--- a/C--/Lexer.cpp
+++ b/C--/Lexer.cpp
@@ -11,18 +11,18 @@ Lexer::Lexer(const std::string text) {
 	this->position = 0;
 }
 
-std::vector<std::unique_ptr<Token>> Lexer::tokenize()
+std::vector<std::shared_ptr<Token>> Lexer::tokenize()
 {
-	std::vector<std::unique_ptr<Token>> tokens;
+	std::vector<std::shared_ptr<Token>> tokens;
 	while (this->position < this->text.size()) {
 		Token token = this->get_token();
 		if (this->is_token_skipable(token)) continue;
 
-		tokens.push_back(std::make_unique<Token>(token));
+		tokens.push_back(std::make_shared<Token>(token));
 	}
 
 	Token end_of_file = Token(EndOfFileToken, this->position, "", nullptr);
-	tokens.push_back(std::make_unique<Token>(end_of_file));
+	tokens.push_back(std::make_shared<Token>(end_of_file));
 
 	return tokens;
 }

--- a/C--/Lexer.h
+++ b/C--/Lexer.h
@@ -12,7 +12,7 @@ public:
 	std::vector<std::string> diagnostics;
 
 	Lexer(const std::string);
-	std::vector<std::unique_ptr<Token>> tokenize();
+	std::vector<std::shared_ptr<Token>> tokenize();
 
 private:
 	std::string text;

--- a/C--/LiteralExpression.cpp
+++ b/C--/LiteralExpression.cpp
@@ -7,7 +7,7 @@
 
 #include "Token.h"
 
-LiteralExpression::LiteralExpression(std::unique_ptr<Token> token) : Expression(LiteralExpressionType) {
+LiteralExpression::LiteralExpression(std::shared_ptr<Token> token) : Expression(LiteralExpressionType) {
 	this->value = token->value;
 	this->number_token = std::move(number_token);
 }

--- a/C--/LiteralExpression.h
+++ b/C--/LiteralExpression.h
@@ -12,8 +12,8 @@
 class LiteralExpression : public Expression {
 
 public:
-	std::unique_ptr<Token> number_token;
+	std::shared_ptr<Token> number_token;
 	std::any value;
 
-	LiteralExpression(std::unique_ptr<Token>);	
+	LiteralExpression(std::shared_ptr<Token>);
 };

--- a/C--/ParenthesizedExpression.cpp
+++ b/C--/ParenthesizedExpression.cpp
@@ -5,9 +5,9 @@
 #include "Token.h"
 
 
-ParenthesizedExpression::ParenthesizedExpression(std::unique_ptr<Token> open_token, std::unique_ptr<Expression> expression, std::unique_ptr<Token> close_token) : 
+ParenthesizedExpression::ParenthesizedExpression(std::shared_ptr<Token> open_token, std::shared_ptr<Expression> expression, std::shared_ptr<Token> close_token) :
 	Expression(ParenthesizedExpressionType) {
-	this->open_token = std::move(open_token);
-	this->expression = std::move(expression);
-	this->close_token = std::move(close_token);
+	this->open_token = open_token;
+	this->expression = expression;
+	this->close_token = close_token;
 }

--- a/C--/ParenthesizedExpression.h
+++ b/C--/ParenthesizedExpression.h
@@ -7,9 +7,9 @@
 
 class ParenthesizedExpression : public Expression {
 public:
-	std::unique_ptr<Token> open_token;
-	std::unique_ptr<Expression> expression;
-	std::unique_ptr<Token> close_token;
+	std::shared_ptr<Token> open_token;
+	std::shared_ptr<Expression> expression;
+	std::shared_ptr<Token> close_token;
 
-	ParenthesizedExpression(std::unique_ptr<Token>, std::unique_ptr<Expression>, std::unique_ptr<Token>);
+	ParenthesizedExpression(std::shared_ptr<Token>, std::shared_ptr<Expression>, std::shared_ptr<Token>);
 };

--- a/C--/Parser.cpp
+++ b/C--/Parser.cpp
@@ -22,9 +22,10 @@ Parser::Parser(std::string text) {
 	this->position = 0;
 }
 
-std::unique_ptr<Expression> Parser::parse() {
+std::shared_ptr<Expression> Parser::parse() {
 	std::unique_ptr<Expression> expression = this->parse_expression();
-	return std::move(expression);
+	std::shared_ptr<Expression> shared_ptr_exp = std::move(expression);
+	return shared_ptr_exp;
 }
 
 std::unique_ptr<Expression> Parser::parse_expression() {

--- a/C--/Parser.cpp
+++ b/C--/Parser.cpp
@@ -23,52 +23,52 @@ Parser::Parser(std::string text) {
 }
 
 std::shared_ptr<Expression> Parser::parse() {
-	std::unique_ptr<Expression> expression = this->parse_expression();
-	std::shared_ptr<Expression> shared_ptr_exp = std::move(expression);
-	return shared_ptr_exp;
+	std::shared_ptr<Expression> expression = this->parse_expression();
+	
+	return expression;
 }
 
-std::unique_ptr<Expression> Parser::parse_expression() {
-	std::unique_ptr<Expression> expression = this->parse_term();
+std::shared_ptr<Expression> Parser::parse_expression() {
+	std::shared_ptr<Expression> expression = this->parse_term();
 
 	return expression;
 }
 
-std::unique_ptr<Expression> Parser::parse_term() {
-	std::unique_ptr<Expression> left = this->parse_factor();
+std::shared_ptr<Expression> Parser::parse_term() {
+	std::shared_ptr<Expression> left = this->parse_factor();
 
 	while (this->current().type == PlusToken || this->current().type == MinusToken) {
-		std::unique_ptr<Token> operator_token = std::make_unique<Token>(this->next());
-		std::unique_ptr<Expression> right = this->parse_factor();
-		left = std::make_unique<BinaryExpression>(std::move(left), std::move(operator_token), std::move(right));
+		std::shared_ptr<Token> operator_token = std::make_shared<Token>(this->next());
+		std::shared_ptr<Expression> right = this->parse_factor();
+		left = std::make_shared<BinaryExpression>(left, operator_token, right);
 	}
 
 	return left;
 }
 
-std::unique_ptr<Expression> Parser::parse_factor() {
-	std::unique_ptr<Expression> left = this->parse_primary();
+std::shared_ptr<Expression> Parser::parse_factor() {
+	std::shared_ptr<Expression> left = this->parse_primary();
 
 	while (this->current().type == StarToken || this->current().type == SlashToken) {
-		std::unique_ptr<Token> operator_token = std::make_unique<Token>(this->next());
-		std::unique_ptr<Expression> right = this->parse_primary();
-		std::unique_ptr<Expression> binary_expression(new BinaryExpression(std::move(left), std::move(operator_token), std::move(right)));
-		left = std::move(binary_expression); // move the BinaryExpression object to the left Expression object
+		std::shared_ptr<Token> operator_token = std::make_shared<Token>(this->next());
+		std::shared_ptr<Expression> right = this->parse_primary();
+		std::shared_ptr<Expression> binary_expression(new BinaryExpression(left, operator_token, right));
+		left = binary_expression; // move the BinaryExpression object to the left Expression object
 	}
 
 	return left;
 }
 
-std::unique_ptr<Expression> Parser::parse_primary() {
+std::shared_ptr<Expression> Parser::parse_primary() {
 	if (this->current().type == NumberToken) {
-		return std::make_unique<LiteralExpression>(std::make_unique<Token>(this->next()));
+		return std::make_shared<LiteralExpression>(std::make_shared<Token>(this->next()));
 	}
 
 	if (this->current().type == OpenParenthesisToken) {
 		Token open = this->next();
-		std::unique_ptr<Expression> expression = this->parse_expression();
+		std::shared_ptr<Expression> expression = this->parse_expression();
 		Token close = this->match(CloseParenthesisToken);
-		return std::make_unique<ParenthesizedExpression>(std::make_unique<Token>(open), std::move(expression), std::make_unique<Token>(close));
+		return std::make_shared<ParenthesizedExpression>(std::make_shared<Token>(open), expression, std::make_shared<Token>(close));
 	}
 
 	Token bad_token = this->next();
@@ -76,7 +76,7 @@ std::unique_ptr<Expression> Parser::parse_primary() {
 	std::string message = "Bad Token. Expected primary, got " + std::to_string(bad_token.type);
 	this->diagnostics.push_back(message);
 
-	return std::make_unique<BadExpression>(std::make_unique<Token>(bad_token));
+	return std::make_shared<BadExpression>(std::make_shared<Token>(bad_token));
 }
 
 Token Parser::match(TokenType expression_type) {

--- a/C--/Parser.h
+++ b/C--/Parser.h
@@ -16,7 +16,7 @@ public:
 	std::vector<std::string> diagnostics;
 
 	Parser(std::string);
-	std::unique_ptr<Expression> parse();
+	std::shared_ptr<Expression> parse();
 
 private:
 	std::unique_ptr<Expression> parse_expression();

--- a/C--/Parser.h
+++ b/C--/Parser.h
@@ -10,7 +10,7 @@
 #include "TokenType.h"
 
 class Parser {
-	std::vector<std::unique_ptr<Token>> tokens;
+	std::vector<std::shared_ptr<Token>> tokens;
 	int position;
 public:
 	std::vector<std::string> diagnostics;
@@ -19,10 +19,10 @@ public:
 	std::shared_ptr<Expression> parse();
 
 private:
-	std::unique_ptr<Expression> parse_expression();
-	std::unique_ptr<Expression> parse_term();
-	std::unique_ptr<Expression> parse_factor();
-	std::unique_ptr<Expression> parse_primary();
+	std::shared_ptr<Expression> parse_expression();
+	std::shared_ptr<Expression> parse_term();
+	std::shared_ptr<Expression> parse_factor();
+	std::shared_ptr<Expression> parse_primary();
 
 	Token match(TokenType);
 	Token current();

--- a/C--/main.cpp
+++ b/C--/main.cpp
@@ -37,12 +37,12 @@ map<int, string> EXPRESSION_TYPE_MAPPER = {
 	{ BadExpressionType, "BadExpressionType" }
 };
 
-void print_expression(Expression* expression, string indent = "") {
+void print_expression(shared_ptr<Expression> expression, string indent = "") {
 	cout << indent << EXPRESSION_TYPE_MAPPER[expression->type] << ':' << endl;
 	indent += '\t';
 
 	if (expression->type == LiteralExpressionType) {
-		LiteralExpression* number_expression = dynamic_cast<LiteralExpression*>(expression);
+		shared_ptr<LiteralExpression> number_expression = dynamic_pointer_cast<LiteralExpression>(expression);
 
 		// Only if number expression is not nullptr (Dynamic cast was successfull)
 		if (number_expression) {
@@ -50,22 +50,22 @@ void print_expression(Expression* expression, string indent = "") {
 		}
 	}
 	else if (expression->type == BinaryExpressionType) {
-		BinaryExpression* binary_expression = dynamic_cast<BinaryExpression*>(expression);
+		shared_ptr<BinaryExpression> binary_expression = dynamic_pointer_cast<BinaryExpression>(expression);
 		
 		// Only if binary expression is not nullptr (Dynamic cast was successfull)
 		if (binary_expression) {
-			print_expression(binary_expression->left.get(), indent);
+			print_expression(binary_expression->left, indent);
 			cout << indent << "Operator Token:" << endl;
 			cout << indent + '\t' << binary_expression->operator_token->raw << endl;
-			print_expression(binary_expression->right.get(), indent);
+			print_expression(binary_expression->right, indent);
 		}
 	}
 	else if (expression->type == ParenthesizedExpressionType) {
-		ParenthesizedExpression* parenthesized_expression = dynamic_cast<ParenthesizedExpression*>(expression);
+		shared_ptr<ParenthesizedExpression> parenthesized_expression = dynamic_pointer_cast<ParenthesizedExpression>(expression);
 
 		// Only if parenthesized expression is not nullptr (Dynamic cast was successfull)
 		if (parenthesized_expression) {
-			print_expression(parenthesized_expression->expression.get(), indent);
+			print_expression(parenthesized_expression->expression, indent);
 		}
 	}
 	else if (expression->type == BadExpressionType) {
@@ -86,9 +86,9 @@ int main() {
 		if (parser.diagnostics.empty()) {
 			Evaluator evaluator;
 
-			print_expression(root.get());
+			print_expression(root);
 
-			cout << "= " << evaluator.evaluate_expression(root.get()) << endl;
+			cout << "= " << evaluator.evaluate_expression(root) << endl;
 		}
 		else {
 			for (auto& diagnostic : parser.diagnostics) {


### PR DESCRIPTION
unique_ptr are changed to shared_ptr in `Parser::parser()` in Parser.cpp and `std::shared_ptr<Expression> root = parser.parse(); ` in main function. In `print_expression()` and `evaluate_expression()` methods `std::unique_ptr<Expression>` are changed to `Expression*`.