### PR TITLE
feat: add precedence and support for unary operators

### DIFF
--- a/C--/C--.vcxproj
+++ b/C--/C--.vcxproj
@@ -139,6 +139,7 @@
     <ClCompile Include="Parser.cpp" />
     <ClCompile Include="ParserRules.cpp" />
     <ClCompile Include="Token.cpp" />
+    <ClCompile Include="UnaryExpression.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BadExpression.h" />
@@ -153,6 +154,7 @@
     <ClInclude Include="ParserRules.h" />
     <ClInclude Include="Token.h" />
     <ClInclude Include="TokenType.h" />
+    <ClInclude Include="UnaryExpression.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/C--/C--.vcxproj
+++ b/C--/C--.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="LiteralExpression.cpp" />
     <ClCompile Include="ParenthesizedExpression.cpp" />
     <ClCompile Include="Parser.cpp" />
+    <ClCompile Include="ParserRules.cpp" />
     <ClCompile Include="Token.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -149,6 +150,7 @@
     <ClInclude Include="LiteralExpression.h" />
     <ClInclude Include="ParenthesizedExpression.h" />
     <ClInclude Include="Parser.h" />
+    <ClInclude Include="ParserRules.h" />
     <ClInclude Include="Token.h" />
     <ClInclude Include="TokenType.h" />
   </ItemGroup>

--- a/C--/Evaluator.cpp
+++ b/C--/Evaluator.cpp
@@ -8,6 +8,7 @@
 
 #include "TokenType.h"
 
+#include "UnaryExpression.h"
 #include "BinaryExpression.h"
 #include "LiteralExpression.h"
 #include "ParenthesizedExpression.h"
@@ -20,9 +21,24 @@ int Evaluator::evaluate_expression(std::shared_ptr<Expression> expression) {
 	if (expression->type == LiteralExpressionType) {
 		std::shared_ptr<LiteralExpression> number_expression = std::dynamic_pointer_cast<LiteralExpression>(expression);
 
-		// Only if number expression is not nullptr (Dynamic cast was successfull)
+		// Only if literal expression is not nullptr (Dynamic cast was successfull)
 		if (number_expression) {
 			return std::any_cast<int>(number_expression->value);
+		}
+	}
+
+	if (expression->type == UnaryExpressionType) {
+		std::shared_ptr<UnaryExpression> unary_expression = std::dynamic_pointer_cast<UnaryExpression>(expression);
+
+		// Only if unary expression is not nullptr (Dynamic cast was successfull)
+		if (unary_expression) {
+			int result = this->evaluate_expression(unary_expression->expression);
+			std::shared_ptr<Token> operator_token = unary_expression->operator_token;
+
+			switch (operator_token->type) {
+			case MinusToken: return -result;
+			case PlusToken: return result;
+			}
 		}
 	}
 

--- a/C--/ExpressionType.h
+++ b/C--/ExpressionType.h
@@ -3,7 +3,11 @@
 
 enum ExpressionType {
 	LiteralExpressionType,
+	UnaryExpressionType,
 	BinaryExpressionType,
 	ParenthesizedExpressionType,
-	BadExpressionType
+
+	BadExpressionType,
+	// Expressions MUST use this ONLY when they are not assigned to a value yet. 
+	EmptyExpressionType 
 };

--- a/C--/Parser.cpp
+++ b/C--/Parser.cpp
@@ -4,9 +4,11 @@
 #include <iostream>
 
 #include "Expression.h"
+
 #include "LiteralExpression.h"
-#include "ParenthesizedExpression.h"
+#include "UnaryExpression.h"
 #include "BinaryExpression.h"
+#include "ParenthesizedExpression.h"
 #include "BadExpression.h"
 
 #include "Lexer.h"
@@ -31,7 +33,19 @@ std::shared_ptr<Expression> Parser::parse() {
 }
 
 std::shared_ptr<Expression> Parser::parse_expression(int parent_precedence) {
-	std::shared_ptr<Expression> left = this->parse_primary();
+	int unary_operator_precedence = ParserRules::get_unary_operator_precedence(this->current().type);
+
+	std::shared_ptr<Expression> left;
+	if (unary_operator_precedence >= parent_precedence && unary_operator_precedence != 0) {
+		std::shared_ptr<Token> operator_token = std::make_shared<Token>(this->next());
+		std::shared_ptr<Expression> expression = this->parse_expression(unary_operator_precedence);
+		std::shared_ptr<Expression> unary_expression(new UnaryExpression(operator_token, expression));
+		left = unary_expression;
+	}
+	else {
+		left = this->parse_primary();
+	}
+
 
 	while (true) {
 		int precedence = ParserRules::get_binary_operator_precedence(this->current().type);

--- a/C--/Parser.h
+++ b/C--/Parser.h
@@ -19,9 +19,7 @@ public:
 	std::unique_ptr<Expression> parse();
 
 private:
-	std::unique_ptr<Expression> parse_expression();
-	std::unique_ptr<Expression> parse_term();
-	std::unique_ptr<Expression> parse_factor();
+	std::unique_ptr<Expression> parse_expression(int = 0);
 	std::unique_ptr<Expression> parse_primary();
 
 	Token match(TokenType);

--- a/C--/ParserRules.cpp
+++ b/C--/ParserRules.cpp
@@ -1,0 +1,19 @@
+#include "ParserRules.h"
+
+#include "TokenType.h"
+
+int ParserRules::get_binary_operator_precedence(TokenType token_type) {
+	switch (token_type)
+	{
+	case StarToken:
+	case SlashToken:
+		return 2;
+
+	case PlusToken:
+	case MinusToken:
+		return 1;
+	
+	default:
+		return 0;
+	}
+}

--- a/C--/ParserRules.cpp
+++ b/C--/ParserRules.cpp
@@ -2,6 +2,18 @@
 
 #include "TokenType.h"
 
+int ParserRules::get_unary_operator_precedence(TokenType token_type) {
+	switch (token_type)
+	{
+	case PlusToken:
+	case MinusToken:
+		return 3;
+
+	default:
+		return 0;
+	}
+}
+
 int ParserRules::get_binary_operator_precedence(TokenType token_type) {
 	switch (token_type)
 	{

--- a/C--/ParserRules.h
+++ b/C--/ParserRules.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "TokenType.h"
+
+class ParserRules
+{
+public:
+	static int get_binary_operator_precedence(TokenType);
+};
+

--- a/C--/ParserRules.h
+++ b/C--/ParserRules.h
@@ -5,6 +5,7 @@
 class ParserRules
 {
 public:
+	static int get_unary_operator_precedence(TokenType);
 	static int get_binary_operator_precedence(TokenType);
 };
 

--- a/C--/UnaryExpression.cpp
+++ b/C--/UnaryExpression.cpp
@@ -1,0 +1,11 @@
+#include <memory>
+
+#include "UnaryExpression.h"
+#include "Expression.h"
+#include "Token.h"
+
+
+UnaryExpression::UnaryExpression(std::shared_ptr<Token> operator_token, std::shared_ptr<Expression> expression) : Expression(UnaryExpressionType) {
+	this->operator_token = operator_token;
+	this->expression = expression;
+}

--- a/C--/UnaryExpression.h
+++ b/C--/UnaryExpression.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+
+#include "Expression.h"
+#include "Token.h"
+
+class UnaryExpression : public Expression {
+public:
+	std::shared_ptr<Token> operator_token;
+	std::shared_ptr<Expression> expression;
+
+	UnaryExpression(std::shared_ptr<Token>, std::shared_ptr<Expression>);
+};
+

--- a/C--/main.cpp
+++ b/C--/main.cpp
@@ -6,7 +6,9 @@
 
 #include "ExpressionType.h"
 #include "Expression.h"
+
 #include "LiteralExpression.h"
+#include "UnaryExpression.h"
 #include "BinaryExpression.h"
 #include "ParenthesizedExpression.h"
 
@@ -32,6 +34,7 @@ map<int, string> TOKEN_TYPE_MAPPER = {
 
 map<int, string> EXPRESSION_TYPE_MAPPER = {
 	{ LiteralExpressionType, "LiteralExpressionType" },
+	{ UnaryExpressionType, "UnaryExpressionType" },
 	{ BinaryExpressionType, "BinaryExpressionType" },
 	{ ParenthesizedExpressionType, "ParenthesizedExpressionType" },
 	{ BadExpressionType, "BadExpressionType" }
@@ -47,6 +50,15 @@ void print_expression(shared_ptr<Expression> expression, string indent = "") {
 		// Only if number expression is not nullptr (Dynamic cast was successfull)
 		if (number_expression) {
 			cout << indent << std::any_cast<int>(number_expression->value) << endl;
+		}
+	}
+	else if (expression->type == UnaryExpressionType) {
+		shared_ptr<UnaryExpression> unary_expression = dynamic_pointer_cast<UnaryExpression>(expression);
+
+		if (unary_expression) {
+			cout << indent << "Operator Token:" << endl;
+			cout << indent << '\t' << unary_expression->operator_token->raw << endl;
+			print_expression(unary_expression->expression, indent);
 		}
 	}
 	else if (expression->type == BinaryExpressionType) {


### PR DESCRIPTION
Instead of using `parse_term` and `parse_factor`, changed it to precedences. Added Unary and BinaryPrecedences. Also added support for unary operators, such as `-` and `+`.