### PR TITLE
feat: add operator classes

### DIFF
--- a/C--/Binder.h
+++ b/C--/Binder.h
@@ -30,11 +30,7 @@ private:
 	std::shared_ptr<BoundExpression> bind_literal_expression(std::shared_ptr<LiteralExpression>);
 	std::shared_ptr<BoundExpression> bind_unary_expression(std::shared_ptr<UnaryExpression>);
 	std::shared_ptr<BoundExpression> bind_binary_expression(std::shared_ptr<BinaryExpression>);
-
-	std::optional<BoundUnaryOperatorType> bind_unary_operator_type(std::shared_ptr<Token>, const std::type_info&);
-	std::optional<BoundBinaryOperatorType> bind_binary_operator_type(std::shared_ptr<Token>, const std::type_info&, const std::type_info&);
 	
-
 	template <typename CastTo, typename CastFrom>
 	std::shared_ptr<CastTo> cast(std::shared_ptr<CastFrom> obj) {
 		return std::dynamic_pointer_cast<CastTo>(obj);

--- a/C--/BoundBinaryExpression.cpp
+++ b/C--/BoundBinaryExpression.cpp
@@ -1,12 +1,17 @@
+#include <typeinfo>
+#include <memory>
+
 #include "BoundBinaryExpression.h"
 
-BoundBinaryExpression::BoundBinaryExpression(std::shared_ptr<BoundExpression> left, BoundBinaryOperatorType operator_type, std::shared_ptr<BoundExpression> right) : 
+#include "BoundExpression.h"
+
+BoundBinaryExpression::BoundBinaryExpression(std::shared_ptr<BoundExpression> left, std::shared_ptr<BoundBinaryOperator> op, std::shared_ptr<BoundExpression> right) : 
     BoundExpression(BoundBinaryExpressionType) {
     this->left = left;
-    this->operator_type = operator_type;
+    this->op = op;
     this->right = right;
 }
 
 const std::type_info& BoundBinaryExpression::type() {
-    return this->left->type();
+    return this->op->result_type;
 }

--- a/C--/BoundBinaryExpression.h
+++ b/C--/BoundBinaryExpression.h
@@ -3,15 +3,15 @@
 #include <memory>
 
 #include "BoundExpression.h"
-#include "BoundBinaryOperatorType.h"
+#include "BoundBinaryOperator.h"
 
 class BoundBinaryExpression : public BoundExpression {
 public:
 	std::shared_ptr<BoundExpression> left;
-	BoundBinaryOperatorType operator_type;
+	std::shared_ptr<BoundBinaryOperator> op;
 	std::shared_ptr<BoundExpression> right;
 
-	BoundBinaryExpression(std::shared_ptr<BoundExpression>, BoundBinaryOperatorType, std::shared_ptr<BoundExpression>);
+	BoundBinaryExpression(std::shared_ptr<BoundExpression>, std::shared_ptr<BoundBinaryOperator>, std::shared_ptr<BoundExpression>);
 	virtual const std::type_info& type() override;
 
 };

--- a/C--/BoundBinaryOperator.cpp
+++ b/C--/BoundBinaryOperator.cpp
@@ -1,0 +1,39 @@
+#include <typeinfo>
+#include <memory>
+#include <optional>
+
+#include "BoundBinaryOperator.h"
+
+#include "BoundBinaryOperatorType.h"
+
+#include "TokenType.h"
+
+
+std::vector<std::shared_ptr<BoundBinaryOperator>> BoundBinaryOperator::operators = {
+	std::make_shared<BoundBinaryOperator>(PlusToken, Addition, typeid(int)),
+	std::make_shared<BoundBinaryOperator>(MinusToken, Subtraction, typeid(int)),
+	std::make_shared<BoundBinaryOperator>(StarToken, Multiplication, typeid(int)),
+	std::make_shared<BoundBinaryOperator>(SlashToken, Division, typeid(int)),
+
+	std::make_shared<BoundBinaryOperator>(AmpersandAmpersandToken, LogicalAnd, typeid(bool)),
+	std::make_shared<BoundBinaryOperator>(PipePipeToken, LogicalOr, typeid(bool)),
+	std::make_shared<BoundBinaryOperator>(PipePipeToken, LogicalOr, typeid(bool)),
+};
+
+BoundBinaryOperator::BoundBinaryOperator(TokenType token_type, BoundBinaryOperatorType bound_binary_operator_type, const std::type_info& type) :
+	BoundBinaryOperator(token_type, bound_binary_operator_type, type, type, type) {}
+
+BoundBinaryOperator::BoundBinaryOperator(TokenType token_type, BoundBinaryOperatorType bound_binary_operator_type, const std::type_info& left_type,
+	const std::type_info& right_type, const std::type_info& result_type) :
+	token_type(token_type), operator_type(bound_binary_operator_type), left_type(left_type), right_type(right_type), result_type(result_type) {}
+
+std::optional<std::shared_ptr<BoundBinaryOperator>> BoundBinaryOperator::bind(TokenType token_type, const std::type_info& left_type, const std::type_info& right_type)
+{
+	for (std::shared_ptr<BoundBinaryOperator> op : BoundBinaryOperator::operators) {
+		if (op->token_type == token_type && op->left_type == left_type && op->right_type == right_type) {
+			return op;
+		}
+	}
+
+	return std::nullopt;
+}

--- a/C--/BoundBinaryOperator.h
+++ b/C--/BoundBinaryOperator.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <typeinfo>
+#include <optional>
+#include <memory>
+#include <vector>
+
+#include "TokenType.h"
+
+#include "BoundBinaryOperatorType.h"
+
+
+class BoundBinaryOperator {
+	static std::vector<std::shared_ptr<BoundBinaryOperator>> operators;
+public:
+	TokenType token_type;
+	BoundBinaryOperatorType operator_type;
+	const std::type_info& left_type;
+	const std::type_info& right_type;
+	const std::type_info& result_type;
+
+	BoundBinaryOperator(TokenType, BoundBinaryOperatorType, const std::type_info&);
+	BoundBinaryOperator(TokenType, BoundBinaryOperatorType, const std::type_info&, const std::type_info&, const std::type_info&);
+
+	static std::optional<std::shared_ptr<BoundBinaryOperator>> bind(TokenType, const std::type_info&, const std::type_info&);
+};
+

--- a/C--/BoundUnaryExpression.cpp
+++ b/C--/BoundUnaryExpression.cpp
@@ -3,13 +3,15 @@
 #include "BoundExpression.h"
 #include "BoundUnaryExpression.h"
 
-BoundUnaryExpression::BoundUnaryExpression(BoundUnaryOperatorType operator_type, std::shared_ptr<BoundExpression> expression) : BoundExpression(BoundUnaryExpressionType)
-{
-	this->operator_type = operator_type;
+#include "BoundUnaryOperator.h"
+
+BoundUnaryExpression::BoundUnaryExpression(std::shared_ptr<BoundUnaryOperator> op, std::shared_ptr<BoundExpression> expression) : 
+	BoundExpression(BoundUnaryExpressionType) {
+	this->op = op;
 	this->expression = expression;
 }
 
 const std::type_info& BoundUnaryExpression::type()
 {
-	return this->expression->type();
+	return this->op->result_type;
 }

--- a/C--/BoundUnaryExpression.h
+++ b/C--/BoundUnaryExpression.h
@@ -4,14 +4,14 @@
 #include <typeinfo>
 
 #include "BoundExpression.h"
-#include "BoundUnaryOperatorType.h"
+#include "BoundUnaryOperator.h"
 
 class BoundUnaryExpression : public BoundExpression {
 public:
-	BoundUnaryOperatorType operator_type;
+	std::shared_ptr<BoundUnaryOperator> op;
 	std::shared_ptr<BoundExpression> expression;
 
-	BoundUnaryExpression(BoundUnaryOperatorType, std::shared_ptr<BoundExpression>);
+	BoundUnaryExpression(std::shared_ptr<BoundUnaryOperator>, std::shared_ptr<BoundExpression>);
 	virtual const std::type_info& type() override;
 };
 

--- a/C--/BoundUnaryOperator.cpp
+++ b/C--/BoundUnaryOperator.cpp
@@ -1,0 +1,32 @@
+#include <typeinfo>
+#include <memory>
+#include <vector>
+
+#include "BoundUnaryOperator.h"
+#include "BoundUnaryOperatorType.h"
+
+#include "TokenType.h"
+
+std::vector<std::shared_ptr<BoundUnaryOperator>> BoundUnaryOperator::operators = {
+	std::make_shared<BoundUnaryOperator>(PlusToken, Identity, typeid(int)),
+	std::make_shared<BoundUnaryOperator>(MinusToken, Identity, typeid(int)),
+
+	std::make_shared<BoundUnaryOperator>(ExclamationToken, LogicalNegation, typeid(bool))
+};
+
+BoundUnaryOperator::BoundUnaryOperator(TokenType token_type, BoundUnaryOperatorType bound_unary_operator, const std::type_info& type) :
+	BoundUnaryOperator(token_type, bound_unary_operator, type, type) {}
+
+BoundUnaryOperator::BoundUnaryOperator(TokenType token_type, BoundUnaryOperatorType bound_unary_operator, const std::type_info& operand_type,
+	const std::type_info& result_type) : token_type(token_type), operator_type(bound_unary_operator), operand_type(operand_type), result_type(result_type) {}
+
+std::optional<std::shared_ptr<BoundUnaryOperator>> BoundUnaryOperator::bind(TokenType token_type, const std::type_info& operand_type)
+{
+	for (const std::shared_ptr<BoundUnaryOperator>& op : BoundUnaryOperator::operators) {
+		if (op->token_type == token_type && op->operand_type == operand_type) {
+			return op;
+		}
+	}
+
+	return std::nullopt;
+}

--- a/C--/BoundUnaryOperator.h
+++ b/C--/BoundUnaryOperator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <typeinfo>
+#include <optional>
+#include <vector>
+
+#include "TokenType.h"
+#include "BoundUnaryOperatorType.h"
+
+
+class BoundUnaryOperator {
+	static std::vector<std::shared_ptr<BoundUnaryOperator>> operators;
+public:
+	TokenType token_type;
+	BoundUnaryOperatorType operator_type;
+	const std::type_info& operand_type;
+	const std::type_info& result_type;
+
+	BoundUnaryOperator(TokenType, BoundUnaryOperatorType, const std::type_info&);
+	BoundUnaryOperator(TokenType, BoundUnaryOperatorType, const std::type_info&, const std::type_info&);
+	static std::optional<std::shared_ptr<BoundUnaryOperator>> bind(TokenType, const std::type_info&);
+};
+

--- a/C--/C--.vcxproj
+++ b/C--/C--.vcxproj
@@ -132,9 +132,11 @@
     <ClCompile Include="BinaryExpression.cpp" />
     <ClCompile Include="Binder.cpp" />
     <ClCompile Include="BoundBinaryExpression.cpp" />
+    <ClCompile Include="BoundBinaryOperator.cpp" />
     <ClCompile Include="BoundExpression.cpp" />
     <ClCompile Include="BoundLiteralExpression.cpp" />
     <ClCompile Include="BoundUnaryExpression.cpp" />
+    <ClCompile Include="BoundUnaryOperator.cpp" />
     <ClCompile Include="Evaluator.cpp" />
     <ClCompile Include="Expression.cpp" />
     <ClCompile Include="Lexer.cpp" />
@@ -152,11 +154,13 @@
     <ClInclude Include="BinaryExpression.h" />
     <ClInclude Include="Binder.h" />
     <ClInclude Include="BoundBinaryExpression.h" />
+    <ClInclude Include="BoundBinaryOperator.h" />
     <ClInclude Include="BoundBinaryOperatorType.h" />
     <ClInclude Include="BoundExpression.h" />
     <ClInclude Include="BoundExpressionType.h" />
     <ClInclude Include="BoundLiteralExpression.h" />
     <ClInclude Include="BoundUnaryExpression.h" />
+    <ClInclude Include="BoundUnaryOperator.h" />
     <ClInclude Include="BoundUnaryOperatorType.h" />
     <ClInclude Include="Evaluator.h" />
     <ClInclude Include="Expression.h" />

--- a/C--/C--.vcxproj.filters
+++ b/C--/C--.vcxproj.filters
@@ -40,6 +40,18 @@
     <Filter Include="Header Files\Frontend\Binding\Types">
       <UniqueIdentifier>{55d6530a-8496-492b-9765-23d480133e86}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\Frontend\Binding\Expressions">
+      <UniqueIdentifier>{d22450ab-5c6d-4175-912d-05d7bcadefe2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Frontend\Binding\Operators">
+      <UniqueIdentifier>{ec6406f9-40a2-4bc1-86df-3f521a411587}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Frontend\Binding\Expressions">
+      <UniqueIdentifier>{7e20a5d3-55b4-45c4-9fae-d585babffd70}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Frontend\Binding\Operators">
+      <UniqueIdentifier>{8c8116d4-f067-4769-add3-4cb645c306be}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -85,16 +97,22 @@
       <Filter>Source Files\Frontend\Binding</Filter>
     </ClCompile>
     <ClCompile Include="BoundBinaryExpression.cpp">
-      <Filter>Source Files\Frontend\Binding</Filter>
+      <Filter>Source Files\Frontend\Binding\Expressions</Filter>
     </ClCompile>
     <ClCompile Include="BoundExpression.cpp">
-      <Filter>Source Files\Frontend\Binding</Filter>
+      <Filter>Source Files\Frontend\Binding\Expressions</Filter>
     </ClCompile>
     <ClCompile Include="BoundLiteralExpression.cpp">
-      <Filter>Source Files\Frontend\Binding</Filter>
+      <Filter>Source Files\Frontend\Binding\Expressions</Filter>
     </ClCompile>
     <ClCompile Include="BoundUnaryExpression.cpp">
-      <Filter>Source Files\Frontend\Binding</Filter>
+      <Filter>Source Files\Frontend\Binding\Expressions</Filter>
+    </ClCompile>
+    <ClCompile Include="BoundBinaryOperator.cpp">
+      <Filter>Source Files\Frontend\Binding\Operators</Filter>
+    </ClCompile>
+    <ClCompile Include="BoundUnaryOperator.cpp">
+      <Filter>Source Files\Frontend\Binding\Operators</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -143,18 +161,6 @@
     <ClInclude Include="Binder.h">
       <Filter>Header Files\Frontend\Binding</Filter>
     </ClInclude>
-    <ClInclude Include="BoundBinaryExpression.h">
-      <Filter>Header Files\Frontend\Binding</Filter>
-    </ClInclude>
-    <ClInclude Include="BoundExpression.h">
-      <Filter>Header Files\Frontend\Binding</Filter>
-    </ClInclude>
-    <ClInclude Include="BoundLiteralExpression.h">
-      <Filter>Header Files\Frontend\Binding</Filter>
-    </ClInclude>
-    <ClInclude Include="BoundUnaryExpression.h">
-      <Filter>Header Files\Frontend\Binding</Filter>
-    </ClInclude>
     <ClInclude Include="BoundBinaryOperatorType.h">
       <Filter>Header Files\Frontend\Binding\Types</Filter>
     </ClInclude>
@@ -163,6 +169,24 @@
     </ClInclude>
     <ClInclude Include="BoundUnaryOperatorType.h">
       <Filter>Header Files\Frontend\Binding\Types</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundBinaryExpression.h">
+      <Filter>Header Files\Frontend\Binding\Expressions</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundExpression.h">
+      <Filter>Header Files\Frontend\Binding\Expressions</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundLiteralExpression.h">
+      <Filter>Header Files\Frontend\Binding\Expressions</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundUnaryExpression.h">
+      <Filter>Header Files\Frontend\Binding\Expressions</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundBinaryOperator.h">
+      <Filter>Header Files\Frontend\Binding\Operators</Filter>
+    </ClInclude>
+    <ClInclude Include="BoundUnaryOperator.h">
+      <Filter>Header Files\Frontend\Binding\Operators</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/C--/Evaluator.cpp
+++ b/C--/Evaluator.cpp
@@ -37,7 +37,7 @@ std::any Evaluator::evaluate_expression(std::shared_ptr<BoundExpression> express
 		if (bound_unary_expression) {
 			std::any result = this->evaluate_expression(bound_unary_expression->expression);
 
-			switch (bound_unary_expression->operator_type)
+			switch (bound_unary_expression->op->operator_type)
 			{
 			case Identity:
 				return std::any_cast<int>(result);
@@ -46,7 +46,7 @@ std::any Evaluator::evaluate_expression(std::shared_ptr<BoundExpression> express
 			case LogicalNegation:
 				return !std::any_cast<bool>(result);
 			default:
-				std::string op_name = Utilities::bound_unary_operator_name(bound_unary_expression->operator_type);
+				std::string op_name = Utilities::bound_unary_operator_name(bound_unary_expression->op->operator_type);
 				throw std::invalid_argument("Unexpected unary operator " + op_name + " for " + result.type().name());
 			}
 		}
@@ -60,7 +60,7 @@ std::any Evaluator::evaluate_expression(std::shared_ptr<BoundExpression> express
 			std::any left = this->evaluate_expression(bound_binary_expression->left);
 			std::any right = this->evaluate_expression(bound_binary_expression->right);
 
-			switch (bound_binary_expression->operator_type) {
+			switch (bound_binary_expression->op->operator_type) {
 			case Addition:
 				return std::any_cast<int>(left) + std::any_cast<int>(right);
 			case Subtraction:
@@ -74,7 +74,7 @@ std::any Evaluator::evaluate_expression(std::shared_ptr<BoundExpression> express
 			case LogicalOr:
 				return std::any_cast<bool>(left) || std::any_cast<bool>(right);
 			default:
-				std::string op_name = Utilities::bound_binary_operator_name(bound_binary_expression->operator_type);
+				std::string op_name = Utilities::bound_binary_operator_name(bound_binary_expression->op->operator_type);
 				throw std::invalid_argument("Unexpected binary operator " + op_name + " for " + left.type().name() + " and " + right.type().name());
 			}
 		}

--- a/C--/Utilities.cpp
+++ b/C--/Utilities.cpp
@@ -159,7 +159,7 @@ void Utilities::print_bound_expression(std::shared_ptr<BoundExpression> expressi
 		//Only if dynamic cast is successful
 		if (bound_unary_expression) {
 			std::cout << indent << "Operator Type: " << std::endl;
-			std::cout << indent + '\t' << Utilities::bound_unary_operator_name(bound_unary_expression->operator_type) << std::endl;
+			std::cout << indent + '\t' << Utilities::bound_unary_operator_name(bound_unary_expression->op->operator_type) << std::endl;
 			print_bound_expression(bound_unary_expression->expression, indent);
 		}
 	}
@@ -170,7 +170,7 @@ void Utilities::print_bound_expression(std::shared_ptr<BoundExpression> expressi
 		if (bound_binary_expression) {
 			print_bound_expression(bound_binary_expression->left, indent);
 			std::cout << indent << "Operator Type: " << std::endl;
-			std::cout << indent + '\t' << Utilities::bound_binary_operator_name(bound_binary_expression->operator_type) << std::endl;
+			std::cout << indent + '\t' << Utilities::bound_binary_operator_name(bound_binary_expression->op->operator_type) << std::endl;
 			print_bound_expression(bound_binary_expression->right, indent);
 		}
 	}


### PR DESCRIPTION
Methods like `bind_unary_operator_type` and `bind_binary_operator_type` was replaced with `BoundUnaryOperator` and `BoundBinaryOperator` classes. They will handle binding the correct operators in their each classes.