### PR TITLE
feat: diagnostics and Compilation

### DIFF
--- a/C--/Binder.cpp
+++ b/C--/Binder.cpp
@@ -27,7 +27,7 @@
 Binder::Binder(std::string line) {
 	Parser parser(line);
 	this->root = parser.parse();
-	this->diagnostics = parser.diagnostics;
+	this->diagnostics.extend(parser.diagnostics);
 }
 
 std::shared_ptr<BoundExpression> Binder::bind() {
@@ -63,6 +63,7 @@ std::shared_ptr<BoundExpression> Binder::bind_unary_expression(std::shared_ptr<U
 		BoundUnaryOperator::bind(expression->operator_token->type, bound_expression->type());
 
 	if (!bound_operator_optional.has_value()) {
+		this->diagnostics.report_undefined_unary_operator(*expression->operator_token.get(), bound_expression->type());
 		return bound_expression;
 	}
 
@@ -83,6 +84,7 @@ std::shared_ptr<BoundExpression> Binder::bind_binary_expression(std::shared_ptr<
 		BoundBinaryOperator::bind(expression->operator_token->type, left->type(), right->type());
 
 	if (!bound_operator_optional.has_value()) {
+		this->diagnostics.report_undefined_binary_operator(*expression->operator_token.get(), left->type(), right->type());
 		return left;
 	}
 

--- a/C--/Binder.cpp
+++ b/C--/Binder.cpp
@@ -24,14 +24,12 @@
 #include "Utilities.h"
 
 
-Binder::Binder(std::string line) {
-	Parser parser(line);
-	this->root = parser.parse();
-	this->diagnostics.extend(parser.diagnostics);
+Binder::Binder(DiagnosticBag diagnostics) {
+	this->diagnostics.extend(diagnostics);
 }
 
-std::shared_ptr<BoundExpression> Binder::bind() {
-	return this->bind_expression(this->root);
+std::shared_ptr<BoundExpression> Binder::bind(std::shared_ptr<Expression> root) {
+	return this->bind_expression(root);
 }
 
 std::shared_ptr<BoundExpression> Binder::bind_expression(std::shared_ptr<Expression> expression) {

--- a/C--/Binder.h
+++ b/C--/Binder.h
@@ -17,9 +17,11 @@
 
 #include "Token.h"
 
+#include "DiagnosticBag.h"
+
 class Binder {
 public:
-	std::vector<std::string> diagnostics;
+	DiagnosticBag diagnostics;
 	Binder(std::string);
 	std::shared_ptr<BoundExpression> bind();
 

--- a/C--/Binder.h
+++ b/C--/Binder.h
@@ -10,6 +10,7 @@
 #include "BoundUnaryOperatorType.h"
 #include "BoundBinaryOperatorType.h"
 
+#include "ExpressionTree.h"
 #include "Expression.h"
 #include "LiteralExpression.h"
 #include "UnaryExpression.h"
@@ -22,12 +23,10 @@
 class Binder {
 public:
 	DiagnosticBag diagnostics;
-	Binder(std::string);
-	std::shared_ptr<BoundExpression> bind();
+	std::shared_ptr<BoundExpression> bind(std::shared_ptr<Expression>);
+	Binder(DiagnosticBag);
 
 private:
-	std::shared_ptr<Expression> root;
-
 	std::shared_ptr<BoundExpression> bind_expression(std::shared_ptr<Expression>);
 	std::shared_ptr<BoundExpression> bind_literal_expression(std::shared_ptr<LiteralExpression>);
 	std::shared_ptr<BoundExpression> bind_unary_expression(std::shared_ptr<UnaryExpression>);

--- a/C--/C--.vcxproj
+++ b/C--/C--.vcxproj
@@ -137,6 +137,8 @@
     <ClCompile Include="BoundLiteralExpression.cpp" />
     <ClCompile Include="BoundUnaryExpression.cpp" />
     <ClCompile Include="BoundUnaryOperator.cpp" />
+    <ClCompile Include="Diagnostic.cpp" />
+    <ClCompile Include="DiagnosticBag.cpp" />
     <ClCompile Include="Evaluator.cpp" />
     <ClCompile Include="Expression.cpp" />
     <ClCompile Include="Lexer.cpp" />
@@ -145,6 +147,7 @@
     <ClCompile Include="ParenthesizedExpression.cpp" />
     <ClCompile Include="Parser.cpp" />
     <ClCompile Include="ParserRules.cpp" />
+    <ClCompile Include="TextSpan.cpp" />
     <ClCompile Include="Token.cpp" />
     <ClCompile Include="UnaryExpression.cpp" />
     <ClCompile Include="Utilities.cpp" />
@@ -162,6 +165,8 @@
     <ClInclude Include="BoundUnaryExpression.h" />
     <ClInclude Include="BoundUnaryOperator.h" />
     <ClInclude Include="BoundUnaryOperatorType.h" />
+    <ClInclude Include="Diagnostic.h" />
+    <ClInclude Include="DiagnosticBag.h" />
     <ClInclude Include="Evaluator.h" />
     <ClInclude Include="Expression.h" />
     <ClInclude Include="ExpressionType.h" />
@@ -170,6 +175,7 @@
     <ClInclude Include="ParenthesizedExpression.h" />
     <ClInclude Include="Parser.h" />
     <ClInclude Include="ParserRules.h" />
+    <ClInclude Include="TextSpan.h" />
     <ClInclude Include="Token.h" />
     <ClInclude Include="TokenType.h" />
     <ClInclude Include="UnaryExpression.h" />

--- a/C--/C--.vcxproj
+++ b/C--/C--.vcxproj
@@ -137,10 +137,13 @@
     <ClCompile Include="BoundLiteralExpression.cpp" />
     <ClCompile Include="BoundUnaryExpression.cpp" />
     <ClCompile Include="BoundUnaryOperator.cpp" />
+    <ClCompile Include="Compilation.cpp" />
     <ClCompile Include="Diagnostic.cpp" />
     <ClCompile Include="DiagnosticBag.cpp" />
+    <ClCompile Include="EvaluationResult.cpp" />
     <ClCompile Include="Evaluator.cpp" />
     <ClCompile Include="Expression.cpp" />
+    <ClCompile Include="ExpressionTree.cpp" />
     <ClCompile Include="Lexer.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="LiteralExpression.cpp" />
@@ -165,10 +168,13 @@
     <ClInclude Include="BoundUnaryExpression.h" />
     <ClInclude Include="BoundUnaryOperator.h" />
     <ClInclude Include="BoundUnaryOperatorType.h" />
+    <ClInclude Include="Compilation.h" />
     <ClInclude Include="Diagnostic.h" />
     <ClInclude Include="DiagnosticBag.h" />
+    <ClInclude Include="EvaluationResult.h" />
     <ClInclude Include="Evaluator.h" />
     <ClInclude Include="Expression.h" />
+    <ClInclude Include="ExpressionTree.h" />
     <ClInclude Include="ExpressionType.h" />
     <ClInclude Include="Lexer.h" />
     <ClInclude Include="LiteralExpression.h" />

--- a/C--/C--.vcxproj.filters
+++ b/C--/C--.vcxproj.filters
@@ -52,6 +52,18 @@
     <Filter Include="Source Files\Frontend\Binding\Operators">
       <UniqueIdentifier>{8c8116d4-f067-4769-add3-4cb645c306be}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Common">
+      <UniqueIdentifier>{a8924d75-e674-4072-acc1-7a8ae9bdcbe4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\Common\Diagnostics">
+      <UniqueIdentifier>{7d151a19-7a06-403f-8239-c6550872023a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Common">
+      <UniqueIdentifier>{71361236-2c11-4a93-9900-18a3997602ce}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Header Files\Common\Diagnostics">
+      <UniqueIdentifier>{081b56e1-c868-45ba-befb-7b2486b20a6a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
@@ -90,9 +102,6 @@
     <ClCompile Include="LiteralExpression.cpp">
       <Filter>Source Files\Frontend\Expressions</Filter>
     </ClCompile>
-    <ClCompile Include="Utilities.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Binder.cpp">
       <Filter>Source Files\Frontend\Binding</Filter>
     </ClCompile>
@@ -113,6 +122,18 @@
     </ClCompile>
     <ClCompile Include="BoundUnaryOperator.cpp">
       <Filter>Source Files\Frontend\Binding\Operators</Filter>
+    </ClCompile>
+    <ClCompile Include="Diagnostic.cpp">
+      <Filter>Source Files\Common\Diagnostics</Filter>
+    </ClCompile>
+    <ClCompile Include="DiagnosticBag.cpp">
+      <Filter>Source Files\Common\Diagnostics</Filter>
+    </ClCompile>
+    <ClCompile Include="TextSpan.cpp">
+      <Filter>Source Files\Common\Diagnostics</Filter>
+    </ClCompile>
+    <ClCompile Include="Utilities.cpp">
+      <Filter>Source Files\Common</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -155,9 +176,6 @@
     <ClInclude Include="ParserRules.h">
       <Filter>Header Files\Frontend</Filter>
     </ClInclude>
-    <ClInclude Include="Utilities.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Binder.h">
       <Filter>Header Files\Frontend\Binding</Filter>
     </ClInclude>
@@ -187,6 +205,18 @@
     </ClInclude>
     <ClInclude Include="BoundUnaryOperator.h">
       <Filter>Header Files\Frontend\Binding\Operators</Filter>
+    </ClInclude>
+    <ClInclude Include="Diagnostic.h">
+      <Filter>Header Files\Common\Diagnostics</Filter>
+    </ClInclude>
+    <ClInclude Include="DiagnosticBag.h">
+      <Filter>Header Files\Common\Diagnostics</Filter>
+    </ClInclude>
+    <ClInclude Include="TextSpan.h">
+      <Filter>Header Files\Common\Diagnostics</Filter>
+    </ClInclude>
+    <ClInclude Include="Utilities.h">
+      <Filter>Header Files\Common</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/C--/C--.vcxproj.filters
+++ b/C--/C--.vcxproj.filters
@@ -135,6 +135,15 @@
     <ClCompile Include="Utilities.cpp">
       <Filter>Source Files\Common</Filter>
     </ClCompile>
+    <ClCompile Include="Compilation.cpp">
+      <Filter>Source Files\Frontend</Filter>
+    </ClCompile>
+    <ClCompile Include="ExpressionTree.cpp">
+      <Filter>Source Files\Frontend\Expressions</Filter>
+    </ClCompile>
+    <ClCompile Include="EvaluationResult.cpp">
+      <Filter>Source Files\Backend</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TokenType.h">
@@ -217,6 +226,15 @@
     </ClInclude>
     <ClInclude Include="Utilities.h">
       <Filter>Header Files\Common</Filter>
+    </ClInclude>
+    <ClInclude Include="ExpressionTree.h">
+      <Filter>Header Files\Frontend\Expressions</Filter>
+    </ClInclude>
+    <ClInclude Include="EvaluationResult.h">
+      <Filter>Header Files\Backend</Filter>
+    </ClInclude>
+    <ClInclude Include="Compilation.h">
+      <Filter>Header Files\Frontend</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/C--/Compilation.cpp
+++ b/C--/Compilation.cpp
@@ -1,0 +1,26 @@
+#include <memory>
+
+#include "Compilation.h"
+#include "Binder.h"
+#include "Evaluator.h"
+#include "EvaluationResult.h"
+
+#include "BoundExpression.h"
+
+Compilation::Compilation(std::shared_ptr<ExpressionTree> tree) {
+	this->tree = tree;
+}
+
+EvaluationResult Compilation::evaluate() {
+	Binder binder(this->tree->diagnostics);
+	std::shared_ptr<BoundExpression> bound_expression = binder.bind(this->tree->root);
+
+	if (!binder.diagnostics.empty()) {
+		return EvaluationResult(binder.diagnostics, std::any());
+	}
+
+	Evaluator evaluator;
+	std::any value = evaluator.evaluate_expression(bound_expression);
+
+	return EvaluationResult(DiagnosticBag(), value);
+}

--- a/C--/Compilation.h
+++ b/C--/Compilation.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+#include "ExpressionTree.h"
+#include "EvaluationResult.h"
+
+
+class Compilation {
+	std::shared_ptr<ExpressionTree> tree;
+
+public:
+	Compilation(std::shared_ptr<ExpressionTree>);
+
+	EvaluationResult evaluate();
+};
+

--- a/C--/Diagnostic.cpp
+++ b/C--/Diagnostic.cpp
@@ -1,0 +1,7 @@
+#include "Diagnostic.h"
+
+Diagnostic::Diagnostic(TextSpan span, std::string message) : span(span), message(message) {}
+
+std::ostream& operator<<(std::ostream& out, const Diagnostic& diagnostic) {
+	return out << diagnostic.message;
+}

--- a/C--/Diagnostic.h
+++ b/C--/Diagnostic.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <ostream>
+#include <string>
+
+#include "TextSpan.h"
+
+class Diagnostic {
+public:
+	TextSpan span;
+	std::string message;
+
+	Diagnostic(TextSpan, std::string);
+
+	friend std::ostream& operator<<(std::ostream& out, const Diagnostic& diagnostic);
+};
+

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -7,6 +7,10 @@ void DiagnosticBag::report(TextSpan span, std::string message) {
 	this->diagnostics.push_back(Diagnostic(span, message));
 }
 
+void DiagnosticBag::extend(const DiagnosticBag& bag) {
+	this->diagnostics.insert(begin(this->diagnostics), begin(bag.diagnostics), end(bag.diagnostics));
+}
+
 void DiagnosticBag::report_invalid_number(int start, int length, std::string raw, const std::type_info& type) {
 	TextSpan span(start, length);
 	std::string message = "The number " + raw + " is not valid " + type.name();

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -1,0 +1,5 @@
+#include "DiagnosticBag.h"
+
+void DiagnosticBag::report(TextSpan span, std::string message) {
+	this->diagnostics.push_back(Diagnostic(span, message));
+}

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -6,6 +6,8 @@
 #include "Token.h"
 #include "TokenType.h"
 
+#include "Utilities.h"
+
 void DiagnosticBag::report(TextSpan span, std::string message) {
 	this->diagnostics.push_back(Diagnostic(span, message));
 }
@@ -30,13 +32,13 @@ void DiagnosticBag::report_bad_character(int start, char character) {
 
 void DiagnosticBag::report_bad_token(Token token) {
 	TextSpan span(token.span);
-	std::string message = "Bad Token. Expected primary, got <" + std::to_string(token.type) + '>';
+	std::string message = "Bad Token. Expected primary, got <" + Utilities::token_name(token.type) + '>';
 
 	this->report(span, message);
 }
 
 void DiagnosticBag::report_unexpected_token(TextSpan span, TokenType actual, TokenType expected) {
-	std::string message = "Unexpected Token. Expected <" + std::to_string(expected) + ", Actual<" + std::to_string(actual) + '>';
+	std::string message = "Unexpected Token. Expected <" + Utilities::token_name(expected) + ", Actual<" + Utilities::token_name(actual) + '>';
 
 	this->report(span, message);
 }

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -42,3 +42,15 @@ void DiagnosticBag::report_unexpected_token(TextSpan span, TokenType actual, Tok
 
 	this->report(span, message);
 }
+
+void DiagnosticBag::report_undefined_unary_operator(Token operator_token, const std::type_info& type) {
+	std::string message = "Unary operator `" + operator_token.raw + "` is not defined for <" + type.name() + '>';
+
+	this->report(operator_token.span, message);
+}
+
+void DiagnosticBag::report_undefined_binary_operator(Token operator_token, const std::type_info& left_type, const std::type_info& right_type) {
+	std::string message = "Binary operator `" + operator_token.raw + "` is not defined for <" + left_type.name() + "> and <" + right_type.name() + '>';
+
+	this->report(operator_token.span, message);
+}

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -1,5 +1,20 @@
+#include <typeinfo>
+#include <string>
+
 #include "DiagnosticBag.h"
 
 void DiagnosticBag::report(TextSpan span, std::string message) {
 	this->diagnostics.push_back(Diagnostic(span, message));
+}
+
+void DiagnosticBag::report_invalid_number(int start, int length, std::string raw, const std::type_info& type) {
+	TextSpan span(start, length);
+	std::string message = "The number " + raw + " is not valid " + type.name();
+	this->report(span, message);
+}
+
+void DiagnosticBag::report_bad_character(int start, char character) {
+	TextSpan span(start, 1);
+	std::string message = "Bad character input: " + character;
+	this->report(span, message);
 }

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -3,6 +3,9 @@
 
 #include "DiagnosticBag.h"
 
+#include "Token.h"
+#include "TokenType.h"
+
 void DiagnosticBag::report(TextSpan span, std::string message) {
 	this->diagnostics.push_back(Diagnostic(span, message));
 }
@@ -13,12 +16,27 @@ void DiagnosticBag::extend(const DiagnosticBag& bag) {
 
 void DiagnosticBag::report_invalid_number(int start, int length, std::string raw, const std::type_info& type) {
 	TextSpan span(start, length);
-	std::string message = "The number " + raw + " is not valid " + type.name();
+	std::string message = "The number <" + raw + " > is not valid <" + type.name() + '>';
+
 	this->report(span, message);
 }
 
 void DiagnosticBag::report_bad_character(int start, char character) {
 	TextSpan span(start, 1);
-	std::string message = "Bad character input: " + character;
+	std::string message = "Bad character input: <" + character + '>';
+
+	this->report(span, message);
+}
+
+void DiagnosticBag::report_bad_token(Token token) {
+	TextSpan span(token.span);
+	std::string message = "Bad Token. Expected primary, got <" + std::to_string(token.type) + '>';
+
+	this->report(span, message);
+}
+
+void DiagnosticBag::report_unexpected_token(TextSpan span, TokenType actual, TokenType expected) {
+	std::string message = "Unexpected Token. Expected <" + std::to_string(expected) + ", Actual<" + std::to_string(actual) + '>';
+
 	this->report(span, message);
 }

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -1,4 +1,5 @@
 #include <typeinfo>
+#include <vector>
 #include <string>
 
 #include "DiagnosticBag.h"
@@ -13,7 +14,19 @@ void DiagnosticBag::report(TextSpan span, std::string message) {
 }
 
 void DiagnosticBag::extend(const DiagnosticBag& bag) {
-	this->diagnostics.insert(begin(this->diagnostics), begin(bag.diagnostics), end(bag.diagnostics));
+	this->diagnostics.insert(this->diagnostics.begin(), bag.diagnostics.begin(), bag.diagnostics.end());
+}
+
+bool DiagnosticBag::empty() {
+	return this->diagnostics.empty();
+}
+
+Diagnostic* DiagnosticBag::begin() {
+	return this->diagnostics.data();
+}
+
+Diagnostic* DiagnosticBag::end() {
+	return this->diagnostics.data() + this->diagnostics.size();
 }
 
 void DiagnosticBag::report_invalid_number(int start, int length, std::string raw, const std::type_info& type) {

--- a/C--/DiagnosticBag.cpp
+++ b/C--/DiagnosticBag.cpp
@@ -31,7 +31,7 @@ Diagnostic* DiagnosticBag::end() {
 
 void DiagnosticBag::report_invalid_number(int start, int length, std::string raw, const std::type_info& type) {
 	TextSpan span(start, length);
-	std::string message = "The number <" + raw + " > is not valid <" + type.name() + '>';
+	std::string message = "The number <" + raw + "> is not valid <" + type.name() + '>';
 
 	this->report(span, message);
 }
@@ -51,7 +51,7 @@ void DiagnosticBag::report_bad_token(Token token) {
 }
 
 void DiagnosticBag::report_unexpected_token(TextSpan span, TokenType actual, TokenType expected) {
-	std::string message = "Unexpected Token. Expected <" + Utilities::token_name(expected) + ", Actual<" + Utilities::token_name(actual) + '>';
+	std::string message = "Unexpected Token. Expected <" + Utilities::token_name(expected) + ">, Actual <" + Utilities::token_name(actual) + '>';
 
 	this->report(span, message);
 }

--- a/C--/DiagnosticBag.h
+++ b/C--/DiagnosticBag.h
@@ -6,6 +6,8 @@
 #include "TextSpan.h"
 #include "Diagnostic.h"
 
+#include "Token.h"
+
 class DiagnosticBag {
 	std::vector<Diagnostic> diagnostics;
 
@@ -15,6 +17,8 @@ public:
 
 	void report_invalid_number(int, int, std::string, const std::type_info&);
 	void report_bad_character(int, char);
-	
+
+	void report_bad_token(Token);
+	void report_unexpected_token(TextSpan, TokenType, TokenType);	
 };
 

--- a/C--/DiagnosticBag.h
+++ b/C--/DiagnosticBag.h
@@ -11,6 +11,7 @@ class DiagnosticBag {
 
 	void report(TextSpan, std::string);
 public:
+	void extend(const DiagnosticBag& diagnostics);
 
 	void report_invalid_number(int, int, std::string, const std::type_info&);
 	void report_bad_character(int, char);

--- a/C--/DiagnosticBag.h
+++ b/C--/DiagnosticBag.h
@@ -14,6 +14,10 @@ class DiagnosticBag {
 	void report(TextSpan, std::string);
 public:
 	void extend(const DiagnosticBag& diagnostics);
+	bool empty();
+
+	Diagnostic* begin();
+	Diagnostic* end();
 
 	void report_invalid_number(int, int, std::string, const std::type_info&);
 	void report_bad_character(int, char);

--- a/C--/DiagnosticBag.h
+++ b/C--/DiagnosticBag.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <vector>
+
+#include "TextSpan.h"
+#include "Diagnostic.h"
+
+class DiagnosticBag {
+	std::vector<Diagnostic> diagnostics;
+
+	void report(TextSpan, std::string);
+public:
+	
+};
+

--- a/C--/DiagnosticBag.h
+++ b/C--/DiagnosticBag.h
@@ -19,6 +19,9 @@ public:
 	void report_bad_character(int, char);
 
 	void report_bad_token(Token);
-	void report_unexpected_token(TextSpan, TokenType, TokenType);	
+	void report_unexpected_token(TextSpan, TokenType, TokenType);
+
+	void report_undefined_unary_operator(Token, const std::type_info&);
+	void report_undefined_binary_operator(Token, const std::type_info&, const std::type_info&);
 };
 

--- a/C--/DiagnosticBag.h
+++ b/C--/DiagnosticBag.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <typeinfo>
 #include <vector>
 
 #include "TextSpan.h"
@@ -10,6 +11,9 @@ class DiagnosticBag {
 
 	void report(TextSpan, std::string);
 public:
+
+	void report_invalid_number(int, int, std::string, const std::type_info&);
+	void report_bad_character(int, char);
 	
 };
 

--- a/C--/EvaluationResult.cpp
+++ b/C--/EvaluationResult.cpp
@@ -1,0 +1,6 @@
+#include "EvaluationResult.h"
+
+EvaluationResult::EvaluationResult(DiagnosticBag diagnostics, std::any value) {
+	this->diagnostics.extend(diagnostics);
+	this->value = value;
+}

--- a/C--/EvaluationResult.h
+++ b/C--/EvaluationResult.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <any>
+
+#include "DiagnosticBag.h"
+
+class EvaluationResult {
+public:
+	DiagnosticBag diagnostics;
+	std::any value;
+
+	EvaluationResult(DiagnosticBag, std::any);
+};
+

--- a/C--/ExpressionTree.cpp
+++ b/C--/ExpressionTree.cpp
@@ -1,0 +1,21 @@
+#include <memory>
+
+#include "ExpressionTree.h"
+#include "Expression.h"
+#include "Token.h"
+
+#include "DiagnosticBag.h"
+
+#include "Parser.h"
+
+ExpressionTree::ExpressionTree(DiagnosticBag diagnostics, std::shared_ptr<Expression> root, std::shared_ptr<Token> end_of_file_token) {
+	this->diagnostics.extend(diagnostics);
+	this->root = root;
+	this->end_of_file_token = end_of_file_token;
+}
+
+std::shared_ptr<ExpressionTree> ExpressionTree::parse(std::string line) {
+	Parser parser(line);
+
+	return parser.parse();
+}

--- a/C--/ExpressionTree.h
+++ b/C--/ExpressionTree.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <memory>
+#include <string>
+
+#include "Expression.h"
+#include "Token.h"
+
+#include "DiagnosticBag.h"
+
+class ExpressionTree {
+public:
+	DiagnosticBag diagnostics;
+	std::shared_ptr<Expression> root;
+	std::shared_ptr<Token> end_of_file_token;
+
+	ExpressionTree(DiagnosticBag, std::shared_ptr<Expression>, std::shared_ptr<Token>);
+
+	static std::shared_ptr<ExpressionTree> parse(std::string);
+};
+

--- a/C--/Lexer.h
+++ b/C--/Lexer.h
@@ -1,18 +1,23 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 #include <memory>
 
 #include "Token.h"
 
+#include "DiagnosticBag.h"
+
 
 class Lexer {
 public:
-	std::vector<std::string> diagnostics;
+	DiagnosticBag diagnostics;
 
 	Lexer(const std::string);
 	std::vector<std::shared_ptr<Token>> tokenize();
+
+	std::optional<int> parse_int(std::string);
 
 private:
 	std::string text;

--- a/C--/Parser.cpp
+++ b/C--/Parser.cpp
@@ -23,7 +23,7 @@
 Parser::Parser(std::string text) {
 	Lexer lexer = Lexer(text);
 	this->tokens = lexer.tokenize();
-	this->diagnostics = lexer.diagnostics;
+	this->diagnostics.extend(lexer.diagnostics);
 	this->position = 0;
 }
 
@@ -79,9 +79,7 @@ std::shared_ptr<Expression> Parser::parse_primary() {
 
 	Token bad_token = this->next();
 
-	std::string message = "Bad Token. Expected primary, got " + std::to_string(bad_token.type);
-	this->diagnostics.push_back(message);
-
+	this->diagnostics.report_bad_token(bad_token);
 	return std::make_shared<BadExpression>(std::make_shared<Token>(bad_token));
 }
 
@@ -90,9 +88,7 @@ Token Parser::match(TokenType expression_type) {
 		return this->next();
 	}
 
-	std::string message = "Bad Token. Expected " + std::to_string(expression_type) + ", but instead got " + std::to_string(this->current().type);
-	this->diagnostics.push_back(message);
-
+	this->diagnostics.report_unexpected_token(this->current().span, this->current().type, expression_type);
 	return Token(expression_type, 0, "", nullptr);
 }
 

--- a/C--/Parser.h
+++ b/C--/Parser.h
@@ -9,11 +9,13 @@
 #include "Token.h"
 #include "TokenType.h"
 
+#include "DiagnosticBag.h"
+
 class Parser {
 	std::vector<std::shared_ptr<Token>> tokens;
 	int position;
 public:
-	std::vector<std::string> diagnostics;
+	DiagnosticBag diagnostics;
 
 	Parser(std::string);
 	std::shared_ptr<Expression> parse();

--- a/C--/Parser.h
+++ b/C--/Parser.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <memory>
 
+#include "ExpressionTree.h"
 #include "Expression.h"
 
 #include "Token.h"
@@ -18,7 +19,7 @@ public:
 	DiagnosticBag diagnostics;
 
 	Parser(std::string);
-	std::shared_ptr<Expression> parse();
+	std::shared_ptr<ExpressionTree> parse();
 
 private:
 	std::shared_ptr<Expression> parse_expression(int = 0);

--- a/C--/TextSpan.cpp
+++ b/C--/TextSpan.cpp
@@ -1,0 +1,7 @@
+#include "TextSpan.h"
+
+TextSpan::TextSpan(int start, int length) {
+	this->start = start;
+	this->length = length;
+	this->end = start + length;
+}

--- a/C--/TextSpan.h
+++ b/C--/TextSpan.h
@@ -1,0 +1,10 @@
+#pragma once
+class TextSpan {
+public:
+	int start;
+	int length;
+	int end;
+
+	TextSpan(int, int);
+};
+

--- a/C--/Token.cpp
+++ b/C--/Token.cpp
@@ -1,6 +1,8 @@
 #include "Token.h"
 
-Token::Token(TokenType type, int position, std::string raw, std::any value) {
+#include "TextSpan.h"
+
+Token::Token(TokenType type, int position, std::string raw, std::any value) : span(position, raw.size()) {
 	this->type = type;
 	this->position = position;
 	this->raw = raw;

--- a/C--/Token.h
+++ b/C--/Token.h
@@ -5,12 +5,15 @@
 
 #include "TokenType.h"
 
+#include "TextSpan.h"
+
 class Token {
 public:
 	TokenType type;
 	int position;
 	std::string raw;
 	std::any value;
+	TextSpan span;
 
 	Token(TokenType, int, std::string, std::any);
 	Token(TokenType, int, char, std::any);

--- a/C--/main.cpp
+++ b/C--/main.cpp
@@ -9,6 +9,7 @@
 #include "TokenType.h"
 #include "Token.h"
 
+#include "ExpressionTree.h"
 #include "ExpressionType.h"
 #include "Expression.h"
 
@@ -19,6 +20,8 @@
 
 #include "BoundExpression.h"
 
+#include "Compilation.h"
+
 #include "Utilities.h"
 
 int main() {
@@ -27,33 +30,25 @@ int main() {
 		std::cout << "> ";
 		std::getline(std::cin, line);
 
-		Binder binder = Binder(line);
-		std::shared_ptr<BoundExpression> root = binder.bind();
+		std::shared_ptr<ExpressionTree> tree = ExpressionTree::parse(line);
 
-		if (!binder.diagnostics.empty()) {
-			for (auto& diagnostic : binder.diagnostics) {
+		Compilation compilation(tree);
+		EvaluationResult result = compilation.evaluate();
+
+		if (!result.diagnostics.empty()) {
+			for (auto& diagnostic : result.diagnostics) {
 				std::cout << diagnostic << std::endl;
 			}
 			continue;
 		}
 
-		Utilities::print_bound_expression(root);
-
-		Evaluator evaluator;
-		std::any result = evaluator.evaluate_expression(root);
-
-		if (!evaluator.diagnostics.empty()) {
-			for (auto& diagnostic : evaluator.diagnostics) {
-				std::cout << diagnostic << std::endl;
-			}
-			continue;
+		Utilities::print_expression(tree->root);
+		
+		if (result.value.type() == typeid(bool)) {
+			std::cout << "= " << std::boolalpha << std::any_cast<bool>(result.value) << std::endl;
 		}
-
-		if (result.type() == typeid(bool)) {
-			std::cout << "= " << std::boolalpha << std::any_cast<bool>(result) << std::endl;
-		}
-		else if (result.type() == typeid(int)) {
-			std::cout << "= " << std::any_cast<int>(result) << std::endl;
+		else if (result.value.type() == typeid(int)) {
+			std::cout << "= " << std::any_cast<int>(result.value) << std::endl;
 		}
 		else {
 			std::cout << "This type is not supported" << std::endl;


### PR DESCRIPTION
Change simple diagnostics represented as `vector of string` to class-based representation. Added classes:

- TextSpan
- Diagnostic
- DiagnosticBag